### PR TITLE
Test against other Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 language: ruby
 rvm:
+  - 2.1.10
+  - 2.2.5
   - 2.3.1
 before_install: gem install bundler -v 1.12.5

--- a/lib/rspec_nested_transactions.rb
+++ b/lib/rspec_nested_transactions.rb
@@ -3,6 +3,7 @@
 require 'delegate'
 require 'fiber'
 require 'rspec_nested_transactions/version'
+require 'rspec/core'
 
 module RspecNestedTransactions
   class FiberAwareGroup < SimpleDelegator

--- a/rspec_nested_transactions.gemspec
+++ b/rspec_nested_transactions.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 1.12'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_runtime_dependency 'rspec'
+  spec.add_development_dependency 'rake', '>= 10'
+  spec.add_runtime_dependency 'rspec', '~> 3.0'
 end

--- a/spec/rspec_nested_transactions_spec.rb
+++ b/spec/rspec_nested_transactions_spec.rb
@@ -31,34 +31,34 @@ RSpec.describe 'nested_transaction hook', order: :defined,
       example('inner second'){ order << 'inner second' }
 
       example 'blocks are executed in the right order' do
-        expected = <<~END
-          config.before nested_transaction hook
-          config.before part 1
-          inner.before part 1
-          config.before first
-          inner.before first
-          first
-          inner.after  first
-          config.after  first
-          config.before second
-          inner.before second
-          second
-          inner.after  second
-          config.after  second
-          config.before inner
-          inner.before inner
-          config.before inner first
-          inner.before inner first
-          inner first
-          inner.after  inner first
-          config.after  inner first
-          config.before inner second
-          inner.before inner second
-          inner second
-          inner.after  inner second
-          config.after  inner second
-          config.before blocks are executed in the right order
-          inner.before blocks are executed in the right order
+        expected = <<-END
+config.before nested_transaction hook
+config.before part 1
+inner.before part 1
+config.before first
+inner.before first
+first
+inner.after  first
+config.after  first
+config.before second
+inner.before second
+second
+inner.after  second
+config.after  second
+config.before inner
+inner.before inner
+config.before inner first
+inner.before inner first
+inner first
+inner.after  inner first
+config.after  inner first
+config.before inner second
+inner.before inner second
+inner second
+inner.after  inner second
+config.after  inner second
+config.before blocks are executed in the right order
+inner.before blocks are executed in the right order
         END
         expect(order).to eq expected.split("\n")
         previous_count = order.size
@@ -70,15 +70,15 @@ RSpec.describe 'nested_transaction hook', order: :defined,
   # to run before it
   context 'part 2' do
     example 'before and after hooks order is correct' do
-      expected = <<~END
-        inner.after  blocks are executed in the right order
-        config.after  blocks are executed in the right order
-        inner.after  inner
-        config.after  inner
-        inner.after  part 1
-        config.after  part 1
-        config.before part 2
-        config.before before and after hooks order is correct
+      expected = <<-END
+inner.after  blocks are executed in the right order
+config.after  blocks are executed in the right order
+inner.after  inner
+config.after  inner
+inner.after  part 1
+config.after  part 1
+config.before part 2
+config.before before and after hooks order is correct
       END
       expect(order[previous_count..-1]).to eq expected.split("\n")
     end


### PR DESCRIPTION
Hi @rosenfeld,

Thanks for this incredible approach on Database records and RSpec. I've tested out your gem with a legacy Rails project that makes heavy use of FactoryGirl records creation and it increased a single test group from 45 seconds to 30! Also, it completely removed the need of database cleaner.

Unfortunately, that project is using Ruby 2.1.6, and as you described on the current README, it won't work due to Ruby 2.3 squiggly heredoc notation.

For this PR, I've done the following changes:
- [x] ~~Update README explaining it works with Ruby 2.1+ versions~~
- [x] Make RSpec a explicit run time dependency
- [x] Require `rspec/core` to use `RSpec.configure` class method when requiring this gem
- [x] Use old style multi line String for Ruby 2.1, 2.2 compatibility
  - This makes specs a bit uglier, but at least the library works fine in every Ruby 2.1+ 
## Making it work with Rails, ActiveRecord and Postgres

When trying to use this lib against a legacy Rails project, I've faced the following challenges:
- Active record save points + rollbacks don't have a clear API, but they're called when raising exceptions under new transactions
- With this approach, some acceptance tests won't run. This still needs further investigation, but they can easily be segregated with RSpec meta tags as you described in this repository README example

Here's the `nested_transaction` global configuration block that I'm now using:

``` ruby
RSpec.configure do |c|
  c.nested_transaction do |example_or_group, run|
    (run[]; next) unless example_or_group.metadata[:db]

    begin
      ActiveRecord::Base.transaction(:requires_new => true) do
        run[]
        raise 'Rollback!'
      end
    rescue
      # NOOP
    end
  end
end
```
